### PR TITLE
Add Python driver prototype for WRF workflow

### DIFF
--- a/configs/sample.json
+++ b/configs/sample.json
@@ -1,7 +1,8 @@
 {
   "gfs": {
     "base_url": "https://nomads.ncep.noaa.gov/pub/data/nccf/com/gfs/prod/",
-    "file_glob": "gfs.t\d{2}z.pgrb2.0p25.f\d{3}",
+    "file_regex": "gfs\\.t\\d{2}z\\.pgrb2\\.0p25\\.f\\d{3}",
+    "cycle_subdir": "atmos",
     "require_complete_file_count": 121,
     "prefer_latest": true
   },

--- a/configs/sample.json
+++ b/configs/sample.json
@@ -1,0 +1,58 @@
+{
+  "gfs": {
+    "base_url": "https://nomads.ncep.noaa.gov/pub/data/nccf/com/gfs/prod/",
+    "file_glob": "gfs.t\d{2}z.pgrb2.0p25.f\d{3}",
+    "require_complete_file_count": 121,
+    "prefer_latest": true
+  },
+  "paths": {
+    "data_dir": "/home/youruser/wrf/data",
+    "wps_dir": "/home/youruser/wrf/WPS",
+    "wrf_dir": "/home/youruser/wrf/WRF/run",
+    "wps_namelist": "/home/youruser/wrf/WPS/namelist.wps",
+    "wrf_namelist": "/home/youruser/wrf/WRF/run/namelist.input",
+    "scripts_dir": "/home/youruser/wrf/scripts",
+    "output_dir": "/home/youruser/wrf/output",
+    "geogrid_exe": "/home/youruser/wrf/WPS/geogrid.exe",
+    "link_grib_script": "/home/youruser/wrf/WPS/link_grib.csh",
+    "ungrib_exe": "/home/youruser/wrf/WPS/ungrib.exe",
+    "metgrid_exe": "/home/youruser/wrf/WPS/metgrid.exe",
+    "wgrib2_exe": "/usr/local/bin/wgrib2",
+    "mpirun_path": "/usr/bin/mpirun",
+    "real_exe": "/home/youruser/wrf/WRF/run/real.exe",
+    "wrf_exe": "/home/youruser/wrf/WRF/run/wrf.exe",
+    "ncl_path": "/usr/local/bin/ncl",
+    "ffmpeg_path": "/usr/bin/ffmpeg"
+  },
+  "region": {
+    "upper_left_latlon": "41.044190,-96.911967",
+    "lower_right_latlon": "40.525328,-96.467021"
+  },
+  "run": {
+    "max_runs": 5,
+    "force_latest_gfs": true
+  },
+  "physics": [
+    {
+      "name": "baseline",
+      "parameters": {
+        "mp_physics": "2,3,4,5,6,7,8,9,10,11,13,14,16,17,18,19,21,28,30,32",
+        "ra_lw_physics": 7,
+        "ra_sw_physics": 3,
+        "radt": 30,
+        "sf_sfclay_physics": 1,
+        "sf_surface_physics": 2,
+        "bl_pbl_physics": 1,
+        "bldt": 0,
+        "cu_physics": 1,
+        "cudt": 5,
+        "isfflx": 1,
+        "ifsnow": 1,
+        "icloud": 1,
+        "surface_input_source": 1,
+        "num_soil_layers": 4,
+        "sf_urban_physics": 1
+      }
+    }
+  ]
+}

--- a/wrfsharp_py/README.md
+++ b/wrfsharp_py/README.md
@@ -16,9 +16,10 @@ python -m wrfsharp_py.driver configs/sample.json --prep --compute
 
 ## Notes
 
-- `download.py` targets the NOAA NOMADS GFS directory. Adjust `gfs.base_url` and `gfs.file_glob`
-  to match the resolution/cycle you want.
+- `download.py` targets the NOAA NOMADS GFS directory. Adjust `gfs.base_url`, `gfs.cycle_subdir`,
+  and `gfs.file_regex` to match the resolution/cycle you want.
 - The namelist helpers perform string substitution. If your namelist formatting differs, you may
   need to tweak `namelist.py`.
+- `driver.py` uses `wgrib2 -s` to parse start/end dates from the first and last GRIB files.
 - For web visualization alternatives, consider generating NetCDF or GeoTIFF layers and serving
   them via raster tiles (e.g., `xarray` + `rasterio` + `rio-tiler`) instead of MP4.

--- a/wrfsharp_py/README.md
+++ b/wrfsharp_py/README.md
@@ -1,0 +1,24 @@
+# WrfSharp Python Driver (prototype)
+
+This folder contains a Python-first rewrite of the WRF pipeline so you can drive runs via JSON.
+It mirrors the older C# flow but skips database output. The current focus is:
+
+- Download latest GFS assets.
+- Update WPS/WRF namelists.
+- Run WPS and WRF executables.
+- Execute NCL scripts and render PNG sequences into MP4s with ffmpeg.
+
+## Quick start
+
+```bash
+python -m wrfsharp_py.driver configs/sample.json --prep --compute
+```
+
+## Notes
+
+- `download.py` targets the NOAA NOMADS GFS directory. Adjust `gfs.base_url` and `gfs.file_glob`
+  to match the resolution/cycle you want.
+- The namelist helpers perform string substitution. If your namelist formatting differs, you may
+  need to tweak `namelist.py`.
+- For web visualization alternatives, consider generating NetCDF or GeoTIFF layers and serving
+  them via raster tiles (e.g., `xarray` + `rasterio` + `rio-tiler`) instead of MP4.

--- a/wrfsharp_py/__init__.py
+++ b/wrfsharp_py/__init__.py
@@ -1,0 +1,1 @@
+"""Python helpers for running WRF workflows."""

--- a/wrfsharp_py/config.py
+++ b/wrfsharp_py/config.py
@@ -9,7 +9,8 @@ from typing import Any, Dict, List, Mapping, Optional
 @dataclass
 class GfsDownloadConfig:
     base_url: str
-    file_glob: str
+    file_regex: str
+    cycle_subdir: str
     require_complete_file_count: Optional[int] = None
     prefer_latest: bool = True
 
@@ -82,7 +83,8 @@ def load_config(config_path: Path) -> WrfConfig:
 
     gfs = GfsDownloadConfig(
         base_url=_require(gfs_payload, "base_url"),
-        file_glob=_require(gfs_payload, "file_glob"),
+        file_regex=_require(gfs_payload, "file_regex"),
+        cycle_subdir=gfs_payload.get("cycle_subdir", "atmos"),
         require_complete_file_count=gfs_payload.get("require_complete_file_count"),
         prefer_latest=gfs_payload.get("prefer_latest", True),
     )

--- a/wrfsharp_py/config.py
+++ b/wrfsharp_py/config.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Mapping, Optional
+
+
+@dataclass
+class GfsDownloadConfig:
+    base_url: str
+    file_glob: str
+    require_complete_file_count: Optional[int] = None
+    prefer_latest: bool = True
+
+
+@dataclass
+class PathsConfig:
+    data_dir: Path
+    wps_dir: Path
+    wrf_dir: Path
+    wps_namelist: Path
+    wrf_namelist: Path
+    scripts_dir: Path
+    output_dir: Path
+    geogrid_exe: Path
+    link_grib_script: Path
+    ungrib_exe: Path
+    metgrid_exe: Path
+    wgrib2_exe: Path
+    mpirun_path: Path
+    real_exe: Path
+    wrf_exe: Path
+    ncl_path: Path
+    ffmpeg_path: Path
+
+
+@dataclass
+class RegionConfig:
+    upper_left_latlon: str
+    lower_right_latlon: str
+
+
+@dataclass
+class RunConfig:
+    max_runs: int
+    force_latest_gfs: bool
+
+
+@dataclass
+class PhysicsConfig:
+    name: str
+    parameters: Dict[str, Any]
+
+
+@dataclass
+class WrfConfig:
+    paths: PathsConfig
+    gfs: GfsDownloadConfig
+    region: RegionConfig
+    run: RunConfig
+    physics: List[PhysicsConfig]
+
+
+def _require(mapping: Mapping[str, Any], key: str) -> Any:
+    if key not in mapping:
+        raise KeyError(f"Missing required config key: {key}")
+    return mapping[key]
+
+
+def _as_path(value: str) -> Path:
+    return Path(value).expanduser()
+
+
+def load_config(config_path: Path) -> WrfConfig:
+    payload = json.loads(config_path.read_text())
+
+    gfs_payload = _require(payload, "gfs")
+    paths_payload = _require(payload, "paths")
+    region_payload = _require(payload, "region")
+    run_payload = _require(payload, "run")
+
+    gfs = GfsDownloadConfig(
+        base_url=_require(gfs_payload, "base_url"),
+        file_glob=_require(gfs_payload, "file_glob"),
+        require_complete_file_count=gfs_payload.get("require_complete_file_count"),
+        prefer_latest=gfs_payload.get("prefer_latest", True),
+    )
+
+    paths = PathsConfig(
+        data_dir=_as_path(_require(paths_payload, "data_dir")),
+        wps_dir=_as_path(_require(paths_payload, "wps_dir")),
+        wrf_dir=_as_path(_require(paths_payload, "wrf_dir")),
+        wps_namelist=_as_path(_require(paths_payload, "wps_namelist")),
+        wrf_namelist=_as_path(_require(paths_payload, "wrf_namelist")),
+        scripts_dir=_as_path(_require(paths_payload, "scripts_dir")),
+        output_dir=_as_path(_require(paths_payload, "output_dir")),
+        geogrid_exe=_as_path(_require(paths_payload, "geogrid_exe")),
+        link_grib_script=_as_path(_require(paths_payload, "link_grib_script")),
+        ungrib_exe=_as_path(_require(paths_payload, "ungrib_exe")),
+        metgrid_exe=_as_path(_require(paths_payload, "metgrid_exe")),
+        wgrib2_exe=_as_path(_require(paths_payload, "wgrib2_exe")),
+        mpirun_path=_as_path(_require(paths_payload, "mpirun_path")),
+        real_exe=_as_path(_require(paths_payload, "real_exe")),
+        wrf_exe=_as_path(_require(paths_payload, "wrf_exe")),
+        ncl_path=_as_path(_require(paths_payload, "ncl_path")),
+        ffmpeg_path=_as_path(_require(paths_payload, "ffmpeg_path")),
+    )
+
+    region = RegionConfig(
+        upper_left_latlon=_require(region_payload, "upper_left_latlon"),
+        lower_right_latlon=_require(region_payload, "lower_right_latlon"),
+    )
+
+    run = RunConfig(
+        max_runs=int(_require(run_payload, "max_runs")),
+        force_latest_gfs=bool(run_payload.get("force_latest_gfs", True)),
+    )
+
+    physics_payload = payload.get("physics", [])
+    physics = [
+        PhysicsConfig(name=entry.get("name", f"physics_{idx}"), parameters=entry["parameters"])
+        for idx, entry in enumerate(physics_payload)
+    ]
+
+    return WrfConfig(paths=paths, gfs=gfs, region=region, run=run, physics=physics)

--- a/wrfsharp_py/download.py
+++ b/wrfsharp_py/download.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import re
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, List, Tuple
+
+
+@dataclass(frozen=True)
+class GfsListing:
+    cycle_dir: str
+    files: List[str]
+
+
+def _read_url(url: str) -> str:
+    with urllib.request.urlopen(url) as response:
+        return response.read().decode("utf-8", errors="replace")
+
+
+def _find_dirs(page: str) -> List[str]:
+    return sorted(set(re.findall(r"gfs\.\d{8}/\d{2}/", page)))
+
+
+def _find_files(page: str, pattern: str) -> List[str]:
+    regex = re.compile(pattern)
+    return sorted(set(match.group(0) for match in regex.finditer(page)))
+
+
+def list_latest_gfs(base_url: str, file_pattern: str, prefer_latest: bool = True) -> GfsListing:
+    page = _read_url(base_url)
+    dirs = _find_dirs(page)
+    if not dirs:
+        raise RuntimeError(f"No GFS directories found at {base_url}")
+
+    cycle_dir = dirs[-1] if prefer_latest else dirs[0]
+    cycle_url = f"{base_url.rstrip('/')}/{cycle_dir}"
+    cycle_page = _read_url(cycle_url)
+    files = _find_files(cycle_page, file_pattern)
+    if not files:
+        raise RuntimeError(f"No files matching {file_pattern} found at {cycle_url}")
+    return GfsListing(cycle_dir=cycle_dir, files=files)
+
+
+def download_files(base_url: str, cycle_dir: str, files: Iterable[str], target_dir: Path) -> List[Path]:
+    target_dir.mkdir(parents=True, exist_ok=True)
+    downloaded: List[Path] = []
+    for filename in files:
+        url = f"{base_url.rstrip('/')}/{cycle_dir}{filename}"
+        destination = target_dir / filename
+        if destination.exists():
+            downloaded.append(destination)
+            continue
+        with urllib.request.urlopen(url) as response:
+            destination.write_bytes(response.read())
+        downloaded.append(destination)
+    return downloaded
+
+
+def pick_files_for_latest_cycle(
+    base_url: str,
+    file_pattern: str,
+    prefer_latest: bool,
+    required_count: int | None,
+) -> Tuple[GfsListing, bool]:
+    listing = list_latest_gfs(base_url, file_pattern, prefer_latest=True)
+    is_complete = required_count is None or len(listing.files) >= required_count
+
+    if is_complete or prefer_latest:
+        return listing, is_complete
+
+    fallback = list_latest_gfs(base_url, file_pattern, prefer_latest=False)
+    fallback_complete = required_count is None or len(fallback.files) >= required_count
+    return fallback, fallback_complete

--- a/wrfsharp_py/download.py
+++ b/wrfsharp_py/download.py
@@ -27,14 +27,19 @@ def _find_files(page: str, pattern: str) -> List[str]:
     return sorted(set(match.group(0) for match in regex.finditer(page)))
 
 
-def list_latest_gfs(base_url: str, file_pattern: str, prefer_latest: bool = True) -> GfsListing:
+def list_latest_gfs(
+    base_url: str,
+    file_pattern: str,
+    cycle_subdir: str,
+    prefer_latest: bool = True,
+) -> GfsListing:
     page = _read_url(base_url)
     dirs = _find_dirs(page)
     if not dirs:
         raise RuntimeError(f"No GFS directories found at {base_url}")
 
     cycle_dir = dirs[-1] if prefer_latest else dirs[0]
-    cycle_url = f"{base_url.rstrip('/')}/{cycle_dir}"
+    cycle_url = f"{base_url.rstrip('/')}/{cycle_dir}{cycle_subdir.strip('/')}/"
     cycle_page = _read_url(cycle_url)
     files = _find_files(cycle_page, file_pattern)
     if not files:
@@ -42,11 +47,17 @@ def list_latest_gfs(base_url: str, file_pattern: str, prefer_latest: bool = True
     return GfsListing(cycle_dir=cycle_dir, files=files)
 
 
-def download_files(base_url: str, cycle_dir: str, files: Iterable[str], target_dir: Path) -> List[Path]:
+def download_files(
+    base_url: str,
+    cycle_dir: str,
+    cycle_subdir: str,
+    files: Iterable[str],
+    target_dir: Path,
+) -> List[Path]:
     target_dir.mkdir(parents=True, exist_ok=True)
     downloaded: List[Path] = []
     for filename in files:
-        url = f"{base_url.rstrip('/')}/{cycle_dir}{filename}"
+        url = f"{base_url.rstrip('/')}/{cycle_dir}{cycle_subdir.strip('/')}/{filename}"
         destination = target_dir / filename
         if destination.exists():
             downloaded.append(destination)
@@ -60,15 +71,16 @@ def download_files(base_url: str, cycle_dir: str, files: Iterable[str], target_d
 def pick_files_for_latest_cycle(
     base_url: str,
     file_pattern: str,
+    cycle_subdir: str,
     prefer_latest: bool,
     required_count: int | None,
 ) -> Tuple[GfsListing, bool]:
-    listing = list_latest_gfs(base_url, file_pattern, prefer_latest=True)
+    listing = list_latest_gfs(base_url, file_pattern, cycle_subdir, prefer_latest=True)
     is_complete = required_count is None or len(listing.files) >= required_count
 
     if is_complete or prefer_latest:
         return listing, is_complete
 
-    fallback = list_latest_gfs(base_url, file_pattern, prefer_latest=False)
+    fallback = list_latest_gfs(base_url, file_pattern, cycle_subdir, prefer_latest=False)
     fallback_complete = required_count is None or len(fallback.files) >= required_count
     return fallback, fallback_complete

--- a/wrfsharp_py/driver.py
+++ b/wrfsharp_py/driver.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 from datetime import datetime
+import re
 from pathlib import Path
 from typing import List
 
@@ -9,22 +10,31 @@ from wrfsharp_py.config import load_config
 from wrfsharp_py.download import download_files, pick_files_for_latest_cycle
 from wrfsharp_py.namelist import update_dates, update_physics
 from wrfsharp_py.physics import expand_all
-from wrfsharp_py.process import run_command
+from wrfsharp_py.process import run_command, run_command_output
 
 
-def _find_grib_dates(grib_files: List[Path]) -> tuple[datetime, datetime]:
+def _parse_wgrib2_date(output: str) -> datetime:
+    match = re.search(r"d=(\d{10})", output)
+    if not match:
+        raise RuntimeError("Unable to parse date from wgrib2 output.")
+    return datetime.strptime(match.group(1), "%Y%m%d%H")
+
+
+def _find_grib_dates(grib_files: List[Path], wgrib2_path: Path) -> tuple[datetime, datetime]:
     if not grib_files:
         raise RuntimeError("No GRIB files were downloaded to inspect dates.")
-    # Placeholder: use file timestamps until wgrib2 integration.
-    times = [datetime.fromtimestamp(path.stat().st_mtime) for path in grib_files]
-    return min(times), max(times)
+    sorted_files = sorted(grib_files)
+    first_output = run_command_output([str(wgrib2_path), "-s", str(sorted_files[0])])
+    last_output = run_command_output([str(wgrib2_path), "-s", str(sorted_files[-1])])
+    return _parse_wgrib2_date(first_output), _parse_wgrib2_date(last_output)
 
 
 def prep_stage(config_path: Path) -> None:
     config = load_config(config_path)
     listing, is_complete = pick_files_for_latest_cycle(
         config.gfs.base_url,
-        config.gfs.file_glob,
+        config.gfs.file_regex,
+        config.gfs.cycle_subdir,
         prefer_latest=config.gfs.prefer_latest,
         required_count=config.gfs.require_complete_file_count,
     )
@@ -34,11 +44,12 @@ def prep_stage(config_path: Path) -> None:
     downloaded = download_files(
         config.gfs.base_url,
         listing.cycle_dir,
+        config.gfs.cycle_subdir,
         listing.files,
         config.paths.data_dir,
     )
 
-    start_date, end_date = _find_grib_dates(downloaded)
+    start_date, end_date = _find_grib_dates(downloaded, config.paths.wgrib2_exe)
     update_dates(config.paths.wps_namelist, start_date, end_date)
     update_dates(config.paths.wrf_namelist, start_date, end_date)
 
@@ -60,9 +71,8 @@ def compute_stage(config_path: Path) -> None:
 
         for script in sorted(config.paths.scripts_dir.glob("*.ncl")):
             run_command([str(config.paths.ncl_path), str(script)], cwd=config.paths.wrf_dir)
-
-        for image_dir in sorted(config.paths.output_dir.glob("*.png")):
-            output_mp4 = config.paths.output_dir / f"{physics.name}.mp4"
+            pattern = str(config.paths.output_dir / f"{script.stem}_*.png")
+            output_mp4 = config.paths.output_dir / f"{script.stem}_{physics.name}.mp4"
             run_command(
                 [
                     str(config.paths.ffmpeg_path),
@@ -72,7 +82,7 @@ def compute_stage(config_path: Path) -> None:
                     "-pattern_type",
                     "glob",
                     "-i",
-                    str(image_dir / "*.png"),
+                    pattern,
                     str(output_mp4),
                 ],
                 cwd=config.paths.output_dir,

--- a/wrfsharp_py/driver.py
+++ b/wrfsharp_py/driver.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import argparse
+from datetime import datetime
+from pathlib import Path
+from typing import List
+
+from wrfsharp_py.config import load_config
+from wrfsharp_py.download import download_files, pick_files_for_latest_cycle
+from wrfsharp_py.namelist import update_dates, update_physics
+from wrfsharp_py.physics import expand_all
+from wrfsharp_py.process import run_command
+
+
+def _find_grib_dates(grib_files: List[Path]) -> tuple[datetime, datetime]:
+    if not grib_files:
+        raise RuntimeError("No GRIB files were downloaded to inspect dates.")
+    # Placeholder: use file timestamps until wgrib2 integration.
+    times = [datetime.fromtimestamp(path.stat().st_mtime) for path in grib_files]
+    return min(times), max(times)
+
+
+def prep_stage(config_path: Path) -> None:
+    config = load_config(config_path)
+    listing, is_complete = pick_files_for_latest_cycle(
+        config.gfs.base_url,
+        config.gfs.file_glob,
+        prefer_latest=config.gfs.prefer_latest,
+        required_count=config.gfs.require_complete_file_count,
+    )
+    if not is_complete and config.run.force_latest_gfs:
+        raise RuntimeError("Latest GFS data is incomplete, and force_latest_gfs is enabled.")
+
+    downloaded = download_files(
+        config.gfs.base_url,
+        listing.cycle_dir,
+        listing.files,
+        config.paths.data_dir,
+    )
+
+    start_date, end_date = _find_grib_dates(downloaded)
+    update_dates(config.paths.wps_namelist, start_date, end_date)
+    update_dates(config.paths.wrf_namelist, start_date, end_date)
+
+    run_command([str(config.paths.geogrid_exe)], cwd=config.paths.wps_dir)
+    run_command([str(config.paths.link_grib_script)], cwd=config.paths.wps_dir)
+    run_command([str(config.paths.ungrib_exe)], cwd=config.paths.wps_dir)
+    run_command([str(config.paths.metgrid_exe)], cwd=config.paths.wps_dir)
+
+
+def compute_stage(config_path: Path) -> None:
+    config = load_config(config_path)
+    physics_runs = expand_all([(entry.name, entry.parameters) for entry in config.physics])
+    runs = physics_runs[: config.run.max_runs]
+
+    for physics in runs:
+        update_physics(config.paths.wrf_namelist, physics.parameters)
+        run_command([str(config.paths.mpirun_path), str(config.paths.real_exe)], cwd=config.paths.wrf_dir)
+        run_command([str(config.paths.mpirun_path), str(config.paths.wrf_exe)], cwd=config.paths.wrf_dir)
+
+        for script in sorted(config.paths.scripts_dir.glob("*.ncl")):
+            run_command([str(config.paths.ncl_path), str(script)], cwd=config.paths.wrf_dir)
+
+        for image_dir in sorted(config.paths.output_dir.glob("*.png")):
+            output_mp4 = config.paths.output_dir / f"{physics.name}.mp4"
+            run_command(
+                [
+                    str(config.paths.ffmpeg_path),
+                    "-y",
+                    "-framerate",
+                    "10",
+                    "-pattern_type",
+                    "glob",
+                    "-i",
+                    str(image_dir / "*.png"),
+                    str(output_mp4),
+                ],
+                cwd=config.paths.output_dir,
+            )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run WRF processing steps.")
+    parser.add_argument("config", type=Path, help="Path to JSON config.")
+    parser.add_argument("--prep", action="store_true", help="Run the data prep stage.")
+    parser.add_argument("--compute", action="store_true", help="Run the compute stage.")
+    args = parser.parse_args()
+
+    if not args.prep and not args.compute:
+        raise SystemExit("Specify --prep and/or --compute")
+
+    if args.prep:
+        prep_stage(args.config)
+    if args.compute:
+        compute_stage(args.config)
+
+
+if __name__ == "__main__":
+    main()

--- a/wrfsharp_py/namelist.py
+++ b/wrfsharp_py/namelist.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import re
+from datetime import datetime
+from pathlib import Path
+from typing import Dict
+
+
+DATE_FIELDS = ("start_date", "end_date")
+
+
+def _format_date(value: datetime) -> str:
+    return value.strftime("%Y-%m-%d_%H:%M:%S")
+
+
+def update_dates(namelist_path: Path, start_date: datetime, end_date: datetime) -> None:
+    content = namelist_path.read_text()
+    date_values = {
+        "start_date": _format_date(start_date),
+        "end_date": _format_date(end_date),
+    }
+    for key, value in date_values.items():
+        pattern = rf"({key}\s*=\s*)([^\n,]+)"
+        content = re.sub(pattern, rf"\1'{value}'", content)
+    namelist_path.write_text(content)
+
+
+def update_physics(namelist_path: Path, parameters: Dict[str, int]) -> None:
+    content = namelist_path.read_text()
+    for key, value in parameters.items():
+        pattern = rf"({re.escape(key)}\s*=\s*)([^\n,]+)"
+        content = re.sub(pattern, rf"\1{value}", content)
+    namelist_path.write_text(content)

--- a/wrfsharp_py/physics.py
+++ b/wrfsharp_py/physics.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from itertools import product
+from typing import Any, Dict, Iterable, List, Tuple
+
+
+@dataclass(frozen=True)
+class PhysicsRun:
+    name: str
+    parameters: Dict[str, int]
+
+
+def _expand_value(value: Any) -> List[int]:
+    if isinstance(value, int):
+        return [value]
+    if isinstance(value, str):
+        parts = [part.strip() for part in value.split(",") if part.strip()]
+        return [int(part) for part in parts]
+    if isinstance(value, Iterable):
+        return [int(part) for part in value]
+    raise ValueError(f"Unsupported physics parameter value: {value}")
+
+
+def expand_physics_config(name: str, parameters: Dict[str, Any]) -> List[PhysicsRun]:
+    keys = list(parameters.keys())
+    values: List[List[int]] = [_expand_value(parameters[key]) for key in keys]
+    runs: List[PhysicsRun] = []
+    for combo in product(*values):
+        run_params = {key: int(value) for key, value in zip(keys, combo)}
+        runs.append(PhysicsRun(name=name, parameters=run_params))
+    return runs
+
+
+def expand_all(configs: Iterable[Tuple[str, Dict[str, Any]]]) -> List[PhysicsRun]:
+    expanded: List[PhysicsRun] = []
+    for name, params in configs:
+        expanded.extend(expand_physics_config(name, params))
+    return expanded

--- a/wrfsharp_py/process.py
+++ b/wrfsharp_py/process.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import Iterable, Optional
+
+
+def run_command(command: Iterable[str], cwd: Optional[Path] = None) -> None:
+    completed = subprocess.run(list(command), cwd=str(cwd) if cwd else None, check=False)
+    if completed.returncode != 0:
+        raise RuntimeError(f"Command failed: {' '.join(command)}")

--- a/wrfsharp_py/process.py
+++ b/wrfsharp_py/process.py
@@ -9,3 +9,17 @@ def run_command(command: Iterable[str], cwd: Optional[Path] = None) -> None:
     completed = subprocess.run(list(command), cwd=str(cwd) if cwd else None, check=False)
     if completed.returncode != 0:
         raise RuntimeError(f"Command failed: {' '.join(command)}")
+
+
+def run_command_output(command: Iterable[str], cwd: Optional[Path] = None) -> str:
+    completed = subprocess.run(
+        list(command),
+        cwd=str(cwd) if cwd else None,
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    if completed.returncode != 0:
+        raise RuntimeError(f"Command failed: {' '.join(command)}\n{completed.stdout}")
+    return completed.stdout


### PR DESCRIPTION
### Motivation
- Provide a Python-first, JSON-driven replacement for the legacy WRF pipeline that avoids using a database and focuses on generating visualizable outputs. 
- Allow using the latest GFS assets by default and make physics/physics-sweep parameters easily tweakable from a JSON file. 
- Keep existing NCL + `ffmpeg` rendering flow while making it easier to extend toward web-friendly outputs (e.g., NetCDF/GeoTIFF tile generation).

### Description
- Add a new `wrfsharp_py` package with modules: `config.py` (JSON config loading into dataclasses), `download.py` (list/download GFS files), `namelist.py` (update namelist dates and physics), `physics.py` (expand physics parameter sweeps), `process.py` (run external commands), and `driver.py` (CLI with `--prep` and `--compute` stages). 
- Introduce a sample JSON config `configs/sample.json` that mirrors previous physics settings and runtime/path options, and treat `gfs.prefer_latest` / `require_complete_file_count` to pick cycles. 
- Implement a simple physics expansion that accepts comma-separated or iterable parameter definitions and emits `PhysicsRun` combinations to limit to `run.max_runs`. 
- Document usage and notes in `wrfsharp_py/README.md`, and use file timestamps as a placeholder for GRIB date extraction until `wgrib2` parsing is added.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696c32d74984832c8ce7f44095a4e3f0)